### PR TITLE
Don't flag normal ascii letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,8 @@ true
 ]
 
 // It also thinks some parts of ascii confusing
-> confusables('mI01')
+> confusables('01')
 [
-  { point: 'm', similarTo: 'rn' },
-  { point: 'I', similarTo: 'l' },
   { point: '0', similarTo: 'O' },
   { point: '1', similarTo: 'l' }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unicode-confusables",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Utility for finding confusing unicode in strings",
   "author": "Ty <lastcanal@gmail.com>",
   "main": "index.js",

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -15,6 +15,11 @@ function logProgress (entries) {
   process.stdout.write(`Processing ${entries} entries...`)
 }
 
+function isASCIILetter (char) {
+  const code = char.charCodeAt(0)
+  return (code >= 65 && code <= 90) || (code >= 97 && code <=122)
+}
+
 https.get('https://unicode.org/Public/security/10.0.0/confusables.txt', (resp) => {
   let extra = ''
   let entries = 0
@@ -25,8 +30,10 @@ https.get('https://unicode.org/Public/security/10.0.0/confusables.txt', (resp) =
     if (!line || line[0] === '#') return;
     let split = line.split(';');
     let from = extract(split[0]);
-    map[from] = extract(split[1]);
-    logProgress(entries += 1)
+    if (!isASCIILetter(from)) {
+      map[from] = extract(split[1]);
+      logProgress(entries += 1)
+    }
   }
 
   resp.on('data', (chunk) => {

--- a/test.js
+++ b/test.js
@@ -86,7 +86,9 @@ const CONFUSING = {
 const NOT_CONFUSING = [
   'vitalik',
   '👻', // ghost emoji
-  '日本刀'
+  '日本刀',
+  'markd.eth',
+  'Indiana'
 ]
 
 describe('isConfusing', () => {


### PR DESCRIPTION
Hello! 

I found this package via [metamask](https://github.com/MetaMask/metamask-extension/pull/9187). I emailed the unicode mailing list about this and am waiting to hear back. I think the unicode confusables.txt is too sensitive. On line 3344, of the [confusables.txt](https://www.unicode.org/Public/security/14.0.0/confusables.txt) it flags the ascii lowercase "m" as a source of a confusable.

I'm not sure how quick unicode folks would be willing to change the confusables.txt. I propose a bit of a kludge where we manually decide not to flag ascii letters as confusing. (In this case "m" and "I" are considered confusing. Somehow "o" is not considered confusing.)

This is causing some problems for me, because my ENS name is `markd.eth`.  Metamask is currently flagging my name as "a potential scam" just because I have an "m" in my name.

![image](https://user-images.githubusercontent.com/11080462/120958707-1c67d080-c70d-11eb-9fc2-116965d3c218.png)
